### PR TITLE
Fix call to KINFree in kinsol_mkinTest.jl

### DIFF
--- a/examples/kinsol_mkinTest.jl
+++ b/examples/kinsol_mkinTest.jl
@@ -44,6 +44,6 @@ residual = ones(2)
 sysfn(y, residual, [1,2])
 println("Residual: ", residual)
 
-## Sundials.KINFree(kmem)   # segfaults, probably because Julia arrays and NVectors share memory
+Sundials.KINFree([kmem])
 
 


### PR DESCRIPTION
Pass kmem in an array because KINFree wants a pointer to a pointer.
